### PR TITLE
Add some no-ops to Stripe webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Added no-ops for some Stripe wehbooks
+    - invoice.payment_succeeded no-op if billing_reason is subscription_cycle
+    - customer.subscription.updated no-op if status is incomplete or incomplete_expired
+
 ## [0.11.7] - 2022-04-24
 
 ### Added

--- a/apps/next/pages/api/stripe/webhook.ts
+++ b/apps/next/pages/api/stripe/webhook.ts
@@ -361,6 +361,13 @@ handler.post(async (req, res) => {
                 case 'invoice.payment_succeeded': {
                     const data = event.data.object as Stripe.Invoice;
 
+                    // For now, don't process events for invoices that are just a recurring payment.
+                    // (aka not the first invoice for a subscription)
+                    // More info: https://stripe.com/docs/api/invoices/object#invoice_object-billing_reason
+                    if (data.billing_reason === 'subscription_cycle') {
+                        break;
+                    }
+
                     const invoiceInfo = await getInvoiceInformation(data);
 
                     // we need a way to get the partner (if they exist)

--- a/apps/next/pages/api/stripe/webhook.ts
+++ b/apps/next/pages/api/stripe/webhook.ts
@@ -251,6 +251,15 @@ handler.post(async (req, res) => {
                 case 'customer.subscription.updated': {
                     const data = event.data.object as Stripe.Subscription;
 
+                    // We don't insert the subscription into the db if it is not active.
+                    // so we don't handle customer.subscription.update events if the status is 'incomplete' or 'incomplete_expired'.
+                    // Read more: https://stripe.com/docs/api/subscriptions/object#subscription_object-status
+                    if (data.collection_method === 'charge_automatically') {
+                        if (data.status === 'incomplete' || data.status === 'incomplete_expired') {
+                            break;
+                        }
+                    }
+
                     await prisma.subscription.update({
                         where: {
                             id: data.id,


### PR DESCRIPTION
- Added no-ops for some Stripe wehbooks
    - invoice.payment_succeeded no-op if billing_reason is subscription_cycle
    - customer.subscription.updated no-op if status is incomplete or incomplete_expired